### PR TITLE
Feature/#3 notifications

### DIFF
--- a/src/main/java/ch/pitaya/pitaya/controller/CaseController.java
+++ b/src/main/java/ch/pitaya/pitaya/controller/CaseController.java
@@ -19,12 +19,14 @@ import ch.pitaya.pitaya.exception.ResourceNotFoundException;
 import ch.pitaya.pitaya.model.Case;
 import ch.pitaya.pitaya.model.File;
 import ch.pitaya.pitaya.model.Firm;
+import ch.pitaya.pitaya.model.NotificationType;
 import ch.pitaya.pitaya.payload.request.CreateCaseRequest;
 import ch.pitaya.pitaya.payload.response.CaseDetails;
 import ch.pitaya.pitaya.payload.response.CaseSummary;
 import ch.pitaya.pitaya.payload.response.FileSummary;
 import ch.pitaya.pitaya.repository.CaseRepository;
 import ch.pitaya.pitaya.security.SecurityFacade;
+import ch.pitaya.pitaya.service.NotificationService;
 import ch.pitaya.pitaya.util.Utils;
 
 @RestController
@@ -33,6 +35,9 @@ public class CaseController {
 
 	@Autowired
 	private SecurityFacade securityFacade;
+
+	@Autowired
+	private NotificationService notificationService;
 
 	@Autowired
 	private CaseRepository caseRepository;
@@ -61,6 +66,7 @@ public class CaseController {
 		Firm firm = securityFacade.getCurrentFirm();
 		Case case_ = caseRepository
 				.save(new Case(firm, request.getNumber(), request.getTitle(), request.getDescription()));
+		notificationService.add(NotificationType.CASE_CREATED, case_);
 		return new CaseDetails(case_);
 	}
 

--- a/src/main/java/ch/pitaya/pitaya/controller/FirmController.java
+++ b/src/main/java/ch/pitaya/pitaya/controller/FirmController.java
@@ -70,4 +70,5 @@ public class FirmController {
 		List<User> users = securityFacade.getCurrentFirm().getUsers();
 		return Utils.map(users, UserSummary::new);
 	}
+
 }

--- a/src/main/java/ch/pitaya/pitaya/controller/NotificationController.java
+++ b/src/main/java/ch/pitaya/pitaya/controller/NotificationController.java
@@ -1,0 +1,83 @@
+package ch.pitaya.pitaya.controller;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import ch.pitaya.pitaya.exception.ResourceNotFoundException;
+import ch.pitaya.pitaya.model.Case;
+import ch.pitaya.pitaya.model.File;
+import ch.pitaya.pitaya.model.Firm;
+import ch.pitaya.pitaya.model.Notification;
+import ch.pitaya.pitaya.model.User;
+import ch.pitaya.pitaya.payload.response.NotificationResponse;
+import ch.pitaya.pitaya.repository.CaseRepository;
+import ch.pitaya.pitaya.repository.FileRepository;
+import ch.pitaya.pitaya.security.SecurityFacade;
+import ch.pitaya.pitaya.service.NotificationService;
+import ch.pitaya.pitaya.util.Utils;
+
+@RestController
+@RequestMapping("/api")
+public class NotificationController {
+
+	@Autowired
+	SecurityFacade securityFacade;
+
+	@Autowired
+	NotificationService notificationService;
+
+	@Autowired
+	CaseRepository caseRepository;
+
+	@Autowired
+	FileRepository fileRepository;
+
+	@GetMapping("/user/changes")
+	public List<NotificationResponse> getUserNotifications(//
+			@RequestParam(name = "page", defaultValue = "0") int page,
+			@RequestParam(name = "size", defaultValue = "0") int size) {
+		User user = securityFacade.getCurrentUser();
+		List<Notification> notifications = notificationService.getUserNotifications(user, page, size);
+		return Utils.map(notifications, NotificationResponse::new);
+	}
+
+	@GetMapping("/firm/changes")
+	public List<NotificationResponse> getFirmNotifications(//
+			@RequestParam(name = "page", defaultValue = "0") int page,
+			@RequestParam(name = "size", defaultValue = "0") int size) {
+		Firm firm = securityFacade.getCurrentFirm();
+		List<Notification> notifications = notificationService.getFirmNotifications(firm, page, size);
+		return Utils.map(notifications, NotificationResponse::new);
+	}
+
+	@GetMapping("/case/{id}/changes")
+	public List<NotificationResponse> getCaseNotifications(//
+			@PathVariable("id") long caseId, //
+			@RequestParam(name = "page", defaultValue = "0") int page,
+			@RequestParam(name = "size", defaultValue = "0") int size) {
+		Firm firm = securityFacade.getCurrentFirm();
+		Case case_ = caseRepository.findByIdAndFirm(caseId, firm)
+				.orElseThrow(() -> new ResourceNotFoundException("case", "id", caseId));
+		List<Notification> notifications = notificationService.getCaseNotifications(case_, page, size);
+		return Utils.map(notifications, NotificationResponse::new);
+	}
+
+	@GetMapping("/file/{id}/changes")
+	public List<NotificationResponse> getFileNotifications(//
+			@PathVariable("id") long fileId, //
+			@RequestParam(name = "page", defaultValue = "0") int page,
+			@RequestParam(name = "size", defaultValue = "0") int size) {
+		Firm firm = securityFacade.getCurrentFirm();
+		File file = fileRepository.findByIdAndTheCaseFirm(fileId, firm)
+				.orElseThrow(() -> new ResourceNotFoundException("file", "id", fileId));
+		List<Notification> notifications = notificationService.getFileNotifications(file, page, size);
+		return Utils.map(notifications, NotificationResponse::new);
+	}
+
+}

--- a/src/main/java/ch/pitaya/pitaya/controller/UserController.java
+++ b/src/main/java/ch/pitaya/pitaya/controller/UserController.java
@@ -1,7 +1,5 @@
 package ch.pitaya.pitaya.controller;
 
-import java.util.List;
-
 import javax.validation.Valid;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -10,19 +8,15 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import ch.pitaya.pitaya.model.Notification;
 import ch.pitaya.pitaya.model.User;
 import ch.pitaya.pitaya.payload.request.ChangePasswordRequest;
-import ch.pitaya.pitaya.payload.response.NotificationResponse;
 import ch.pitaya.pitaya.payload.response.SimpleResponse;
 import ch.pitaya.pitaya.payload.response.UserSummary;
 import ch.pitaya.pitaya.security.SecurityFacade;
 import ch.pitaya.pitaya.service.NotificationService;
 import ch.pitaya.pitaya.service.UserService;
-import ch.pitaya.pitaya.util.Utils;
 
 @RequestMapping("/api/user")
 @RestController
@@ -47,15 +41,6 @@ public class UserController {
 		User user = securityFacade.getCurrentUser();
 		userService.changePassword(user, request);
 		return SimpleResponse.ok("password changed");
-	}
-
-	@GetMapping("/changes")
-	public List<NotificationResponse> getNotifications(//
-			@RequestParam(name = "page", defaultValue = "0") int page,
-			@RequestParam(name = "size", defaultValue = "0") int size) {
-		User user = securityFacade.getCurrentUser();
-		List<Notification> notifications = notificationService.getUserNotifications(user, page, size);
-		return Utils.map(notifications, NotificationResponse::new);
 	}
 
 }

--- a/src/main/java/ch/pitaya/pitaya/controller/UserController.java
+++ b/src/main/java/ch/pitaya/pitaya/controller/UserController.java
@@ -1,5 +1,7 @@
 package ch.pitaya.pitaya.controller;
 
+import java.util.List;
+
 import javax.validation.Valid;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -8,14 +10,19 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import ch.pitaya.pitaya.model.Notification;
 import ch.pitaya.pitaya.model.User;
 import ch.pitaya.pitaya.payload.request.ChangePasswordRequest;
+import ch.pitaya.pitaya.payload.response.NotificationResponse;
 import ch.pitaya.pitaya.payload.response.SimpleResponse;
 import ch.pitaya.pitaya.payload.response.UserSummary;
 import ch.pitaya.pitaya.security.SecurityFacade;
+import ch.pitaya.pitaya.service.NotificationService;
 import ch.pitaya.pitaya.service.UserService;
+import ch.pitaya.pitaya.util.Utils;
 
 @RequestMapping("/api/user")
 @RestController
@@ -23,6 +30,9 @@ public class UserController {
 
 	@Autowired
 	SecurityFacade securityFacade;
+
+	@Autowired
+	NotificationService notificationService;
 
 	@Autowired
 	UserService userService;
@@ -37,6 +47,15 @@ public class UserController {
 		User user = securityFacade.getCurrentUser();
 		userService.changePassword(user, request);
 		return SimpleResponse.ok("password changed");
+	}
+
+	@GetMapping("/changes")
+	public List<NotificationResponse> getNotifications(//
+			@RequestParam(name = "page", defaultValue = "0") int page,
+			@RequestParam(name = "size", defaultValue = "0") int size) {
+		User user = securityFacade.getCurrentUser();
+		List<Notification> notifications = notificationService.getUserNotifications(user, page, size);
+		return Utils.map(notifications, NotificationResponse::new);
 	}
 
 }

--- a/src/main/java/ch/pitaya/pitaya/model/Case.java
+++ b/src/main/java/ch/pitaya/pitaya/model/Case.java
@@ -10,6 +10,7 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
+import javax.persistence.OrderBy;
 import javax.persistence.Table;
 import javax.validation.constraints.NotBlank;
 
@@ -33,11 +34,12 @@ public class Case {
 
 	@ManyToOne(optional = false, fetch = FetchType.LAZY)
 	private Firm firm;
-	
-	@OneToMany(mappedBy="theCase")
+
+	@OneToMany(mappedBy = "theCase")
 	private List<File> files;
-	
-	@OneToMany(mappedBy="theCase")
+
+	@OneToMany(mappedBy = "theCase")
+	@OrderBy("cre_dat DESC")
 	private List<Notification> notifications;
 
 	protected Case() {
@@ -48,6 +50,7 @@ public class Case {
 		this.caseNumber = caseNumber;
 		this.title = title;
 		this.description = description;
+		this.firm = firm;
 	}
 
 	public void setCaseNumber(String caseNumber) {
@@ -89,11 +92,11 @@ public class Case {
 	public void setDescription(String description) {
 		this.description = description;
 	}
-	
+
 	public List<File> getFiles() {
 		return files;
 	}
-	
+
 	public List<Notification> getNotifications() {
 		return notifications;
 	}

--- a/src/main/java/ch/pitaya/pitaya/model/Case.java
+++ b/src/main/java/ch/pitaya/pitaya/model/Case.java
@@ -36,6 +36,9 @@ public class Case {
 	
 	@OneToMany(mappedBy="theCase")
 	private List<File> files;
+	
+	@OneToMany(mappedBy="theCase")
+	private List<Notification> notifications;
 
 	protected Case() {
 		// JPA
@@ -89,6 +92,10 @@ public class Case {
 	
 	public List<File> getFiles() {
 		return files;
+	}
+	
+	public List<Notification> getNotifications() {
+		return notifications;
 	}
 
 }

--- a/src/main/java/ch/pitaya/pitaya/model/File.java
+++ b/src/main/java/ch/pitaya/pitaya/model/File.java
@@ -11,6 +11,7 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
+import javax.persistence.OrderBy;
 import javax.persistence.Table;
 import javax.persistence.UniqueConstraint;
 import javax.validation.constraints.NotEmpty;
@@ -33,6 +34,7 @@ public class File {
 	private List<FileData> fileData;
 	
 	@OneToMany(mappedBy = "file")
+	@OrderBy("cre_dat DESC")
 	private List<Notification> notifications;
 
 	@NotEmpty

--- a/src/main/java/ch/pitaya/pitaya/model/File.java
+++ b/src/main/java/ch/pitaya/pitaya/model/File.java
@@ -31,6 +31,9 @@ public class File {
 
 	@OneToMany(mappedBy = "file")
 	private List<FileData> fileData;
+	
+	@OneToMany(mappedBy = "file")
+	private List<Notification> notifications;
 
 	@NotEmpty
 	@Size(max = 80)
@@ -72,6 +75,10 @@ public class File {
 
 	public List<FileData> getFileData() {
 		return fileData;
+	}
+	
+	public List<Notification> getNotifications() {
+		return notifications;
 	}
 	
 }

--- a/src/main/java/ch/pitaya/pitaya/model/Firm.java
+++ b/src/main/java/ch/pitaya/pitaya/model/Firm.java
@@ -8,6 +8,7 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.OneToMany;
+import javax.persistence.OrderBy;
 import javax.persistence.Table;
 import javax.validation.constraints.NotBlank;
 
@@ -36,6 +37,7 @@ public class Firm {
 	private List<Case> cases;
 
 	@OneToMany(mappedBy = "firm")
+	@OrderBy("cre_dat DESC")
 	private List<Notification> notifications;
 
 	protected Firm() {

--- a/src/main/java/ch/pitaya/pitaya/model/Firm.java
+++ b/src/main/java/ch/pitaya/pitaya/model/Firm.java
@@ -28,12 +28,15 @@ public class Firm {
 	private String number;
 	private String zipCode;
 	private String city;
-	
-	@OneToMany(mappedBy="firm")
+
+	@OneToMany(mappedBy = "firm")
 	private List<User> users;
-	
-	@OneToMany(mappedBy="firm")
+
+	@OneToMany(mappedBy = "firm")
 	private List<Case> cases;
+
+	@OneToMany(mappedBy = "firm")
+	private List<Notification> notifications;
 
 	protected Firm() {
 		// JPA
@@ -94,9 +97,12 @@ public class Firm {
 	public List<User> getUsers() {
 		return users;
 	}
-	
+
 	public List<Case> getCases() {
 		return cases;
 	}
-	
+
+	public List<Notification> getNotifications() {
+		return notifications;
+	}
 }

--- a/src/main/java/ch/pitaya/pitaya/model/Notification.java
+++ b/src/main/java/ch/pitaya/pitaya/model/Notification.java
@@ -1,0 +1,97 @@
+package ch.pitaya.pitaya.model;
+
+import java.sql.Timestamp;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = "notifications")
+public class Notification {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(nullable = false, updatable = false)
+	private Timestamp cre_dat;
+
+	@ManyToOne(optional = false, fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id", nullable = false, updatable = false)
+	private User user;
+
+	@ManyToOne(optional = false, fetch = FetchType.LAZY)
+	@JoinColumn(name = "firm_id", nullable = false, updatable = false)
+	private Firm firm;
+
+	@ManyToOne(optional = true, fetch = FetchType.LAZY)
+	@JoinColumn(name = "case_id", nullable = true, updatable = false)
+	private Case theCase;
+
+	@ManyToOne(optional = true, fetch = FetchType.LAZY)
+	@JoinColumn(name = "file_id", nullable = true, updatable = false)
+	private File file;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false, updatable = false)
+	private NotificationType type;
+
+	private String notes;
+
+	protected Notification() {
+		// JPA
+	}
+
+	public Notification(NotificationType type, User user, Firm firm, Case theCase, File file, Timestamp time,
+			String notes) {
+		this.user = user;
+		this.theCase = theCase;
+		this.file = file;
+		this.type = type;
+		this.cre_dat = time;
+		this.notes = notes;
+		this.firm = firm;
+	}
+
+	public Long getId() {
+		return id;
+	}
+
+	public User getUser() {
+		return user;
+	}
+
+	public Case getCase() {
+		return theCase;
+	}
+
+	public File getFile() {
+		return file;
+	}
+
+	public NotificationType getType() {
+		return type;
+	}
+
+	public Timestamp getCreationTime() {
+		return cre_dat;
+	}
+
+	public String getNotes() {
+		return notes;
+	}
+
+	public Firm getFirm() {
+		return firm;
+	}
+
+}

--- a/src/main/java/ch/pitaya/pitaya/model/NotificationType.java
+++ b/src/main/java/ch/pitaya/pitaya/model/NotificationType.java
@@ -1,0 +1,7 @@
+package ch.pitaya.pitaya.model;
+
+public enum NotificationType {
+
+	CASE_CREATED, CASE_MODIFIED, FILE_CREATED, FILE_MODIFIED, FILE_VERSION_ADDED
+
+}

--- a/src/main/java/ch/pitaya/pitaya/model/User.java
+++ b/src/main/java/ch/pitaya/pitaya/model/User.java
@@ -53,6 +53,9 @@ public class User {
 	@OneToMany(mappedBy = "user")
 	private List<Token> tokens;
 
+	@OneToMany(mappedBy = "user")
+	private List<Notification> notifications;
+
 	@NotBlank
 	@Column(nullable = false)
 	private String authCodes;
@@ -128,6 +131,10 @@ public class User {
 
 	public List<Token> getTokens() {
 		return tokens;
+	}
+
+	public List<Notification> getNotifications() {
+		return notifications;
 	}
 
 }

--- a/src/main/java/ch/pitaya/pitaya/model/User.java
+++ b/src/main/java/ch/pitaya/pitaya/model/User.java
@@ -10,6 +10,7 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
+import javax.persistence.OrderBy;
 import javax.persistence.Table;
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
@@ -54,6 +55,7 @@ public class User {
 	private List<Token> tokens;
 
 	@OneToMany(mappedBy = "user")
+	@OrderBy("cre_dat DESC")
 	private List<Notification> notifications;
 
 	@NotBlank

--- a/src/main/java/ch/pitaya/pitaya/payload/request/CreateCaseRequest.java
+++ b/src/main/java/ch/pitaya/pitaya/payload/request/CreateCaseRequest.java
@@ -12,12 +12,6 @@ public class CreateCaseRequest {
 
 	private String description;
 
-	public CreateCaseRequest(String number, String title, String description) {
-		this.title = title;
-		this.number = number;
-		this.description = description;
-	}
-
 	public String getNumber() {
 		return number;
 	}

--- a/src/main/java/ch/pitaya/pitaya/payload/response/NotificationResponse.java
+++ b/src/main/java/ch/pitaya/pitaya/payload/response/NotificationResponse.java
@@ -1,0 +1,62 @@
+package ch.pitaya.pitaya.payload.response;
+
+import java.sql.Timestamp;
+
+import ch.pitaya.pitaya.model.Case;
+import ch.pitaya.pitaya.model.File;
+import ch.pitaya.pitaya.model.Firm;
+import ch.pitaya.pitaya.model.Notification;
+import ch.pitaya.pitaya.model.User;
+
+import static ch.pitaya.pitaya.util.Utils.ifNotNull;
+
+public class NotificationResponse {
+
+	private Long id, userId, firmId, caseId, fileId;
+	private String type, notes;
+	private Timestamp time;
+
+	public NotificationResponse(Notification notification) {
+		id = notification.getId();
+		userId = ifNotNull(notification.getUser(), User::getId);
+		firmId = ifNotNull(notification.getFirm(), Firm::getId);
+		caseId = ifNotNull(notification.getCase(), Case::getId);
+		fileId = ifNotNull(notification.getFile(), File::getId);
+		type = notification.getType().toString();
+		notes = notification.getNotes();
+		time = notification.getCreationTime();
+	}
+
+	public Long getId() {
+		return id;
+	}
+
+	public Long getUserId() {
+		return userId;
+	}
+
+	public Long getFirmId() {
+		return firmId;
+	}
+
+	public Long getCaseId() {
+		return caseId;
+	}
+
+	public Long getFileId() {
+		return fileId;
+	}
+
+	public String getType() {
+		return type;
+	}
+
+	public String getNotes() {
+		return notes;
+	}
+
+	public Timestamp getTime() {
+		return time;
+	}
+
+}

--- a/src/main/java/ch/pitaya/pitaya/repository/NotificationRepository.java
+++ b/src/main/java/ch/pitaya/pitaya/repository/NotificationRepository.java
@@ -1,0 +1,9 @@
+package ch.pitaya.pitaya.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import ch.pitaya.pitaya.model.Notification;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+}

--- a/src/main/java/ch/pitaya/pitaya/service/NotificationService.java
+++ b/src/main/java/ch/pitaya/pitaya/service/NotificationService.java
@@ -1,0 +1,80 @@
+package ch.pitaya.pitaya.service;
+
+import java.sql.Timestamp;
+import java.util.Date;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import ch.pitaya.pitaya.model.Case;
+import ch.pitaya.pitaya.model.File;
+import ch.pitaya.pitaya.model.Firm;
+import ch.pitaya.pitaya.model.Notification;
+import ch.pitaya.pitaya.model.NotificationType;
+import ch.pitaya.pitaya.model.User;
+import ch.pitaya.pitaya.repository.NotificationRepository;
+import ch.pitaya.pitaya.security.SecurityFacade;
+import ch.pitaya.pitaya.util.Utils;
+
+@Service
+public class NotificationService {
+
+	@Autowired
+	private SecurityFacade security;
+
+	@Autowired
+	private NotificationRepository repo;
+
+	public void add(NotificationType type) {
+		add(type, null, null, null);
+	}
+
+	public void add(NotificationType type, String notes) {
+		add(type, null, null, notes);
+	}
+
+	public void add(NotificationType type, Case theCase) {
+		add(type, theCase, null, null);
+	}
+
+	public void add(NotificationType type, Case theCase, String notes) {
+		add(type, theCase, null, notes);
+	}
+
+	public void add(NotificationType type, File file) {
+		add(type, file.getCase(), file, null);
+	}
+
+	public void add(NotificationType type, File file, String notes) {
+		add(type, file.getCase(), file, notes);
+	}
+
+	public void add(NotificationType type, Case theCase, File file, String notes) {
+		User user = security.getCurrentUser();
+		add(type, user, user.getFirm(), theCase, file, notes, new Timestamp(new Date().getTime()));
+	}
+
+	public void add(NotificationType type, User user, Firm firm, Case theCase, File file, String notes,
+			Timestamp time) {
+		Notification notification = new Notification(type, user, firm, theCase, file, time, notes);
+		repo.save(notification);
+	}
+
+	public List<Notification> getUserNotifications(User user, int page, int size) {
+		return Utils.paginate(user.getNotifications(), page, size);
+	}
+
+	public List<Notification> getFirmNotifications(Firm firm, int page, int size) {
+		return Utils.paginate(firm.getNotifications(), page, size);
+	}
+
+	public List<Notification> getCaseNotifications(Case case_, int page, int size) {
+		return Utils.paginate(case_.getNotifications(), page, size);
+	}
+
+	public List<Notification> getFileNotifications(File file, int page, int size) {
+		return Utils.paginate(file.getNotifications(), page, size);
+	}
+
+}

--- a/src/main/java/ch/pitaya/pitaya/util/Utils.java
+++ b/src/main/java/ch/pitaya/pitaya/util/Utils.java
@@ -1,8 +1,13 @@
 package ch.pitaya.pitaya.util;
 
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class Utils {
 
@@ -13,6 +18,23 @@ public class Utils {
 		for (T element : list)
 			output.add(f.apply(element));
 		return output;
+	}
+
+	public static <T> List<T> paginate(List<T> list, int start, int size) {
+		return paginate(list, start, size, t -> true);
+	}
+
+	public static <T> List<T> paginate(List<T> list, int start, int size, Predicate<T> filter) {
+		Stream<T> stream = list.stream().filter(filter).skip(start);
+		if (size > 0)
+			stream = stream.limit(size);
+		return stream.collect(Collectors.toList());
+	}
+
+	public static <T, F> F ifNotNull(T t, Function<T, F> f) {
+		if (t == null)
+			return null;
+		return f.apply(t);
 	}
 
 }

--- a/src/main/java/ch/pitaya/pitaya/util/Utils.java
+++ b/src/main/java/ch/pitaya/pitaya/util/Utils.java
@@ -1,7 +1,5 @@
 package ch.pitaya.pitaya.util;
 
-import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
@@ -25,7 +23,7 @@ public class Utils {
 	}
 
 	public static <T> List<T> paginate(List<T> list, int start, int size, Predicate<T> filter) {
-		Stream<T> stream = list.stream().filter(filter).skip(start);
+		Stream<T> stream = list.stream().filter(filter).skip(start * size);
 		if (size > 0)
 			stream = stream.limit(size);
 		return stream.collect(Collectors.toList());


### PR DESCRIPTION
Writing Changes simply issue a notification through one of the NotificationService#add() methods. Notifications are always linked to users, firms and can also be linked to cases or cases&files. This allows these notifications to be read from different points of view:
  - all changes by the current user
  - all changes within the firm
  - all changes to a case
  - all changes to a file 
The notification system also supports pagination

In the future the visible notifications can be filtered server-side to incorporate fine-grained access control.